### PR TITLE
Use rawgit.com for external assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <title>Типограф на JavaScript</title>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="./common.css" type="text/css" />
-        <link rel="stylesheet" href="https://raw.githubusercontent.com/typograf/typograf/master/dist/typograf.css" type="text/css" />
+        <link rel="stylesheet" href="https://rawgit.com/typograf/typograf/master/dist/typograf.css" type="text/css" />
     </head>
     <body class="page_is-desktop">
         <script>
@@ -50,7 +50,7 @@
                 </div>
              </div>
         </div>
-        <script src="https://raw.githubusercontent.com/typograf/typograf/master/dist/typograf.js" defer="defer"></script>
+        <script src="https://rawgit.com/typograf/typograf/master/dist/typograf.js" defer="defer"></script>
         <script src="./common.js" defer="defer"></script>
     </body>
 </html>

--- a/mobile.html
+++ b/mobile.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <meta charset="utf-8" />
         <link rel="stylesheet" href="common.css" type="text/css" />
-        <link rel="stylesheet" href="https://raw.githubusercontent.com/typograf/typograf/master/dist/typograf.css" type="text/css" />
+        <link rel="stylesheet" href="https://rawgit.com/typograf/typograf/master/dist/typograf.css" type="text/css" />
     </head>
     <body class="page_is-mobile">
         <header class="header">
@@ -41,7 +41,7 @@
                 <input type="button" class="input__execute" value="Типографировать" />
             </div>
         </div>
-        <script src="https://raw.githubusercontent.com/typograf/typograf/master/dist/typograf.js" defer="defer"></script>
+        <script src="https://rawgit.com/typograf/typograf/master/dist/typograf.js" defer="defer"></script>
         <script src="common.js" defer="defer"></script>
     </body>
 </html>


### PR DESCRIPTION
В браузере Chrome не работает текущая версия Типографа, из-за ошибки:

```
Refused to execute script from 'https://raw.githubusercontent.com/typograf/typograf/master/dist/typograf.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
```

Дело в том, что raw.githubusercontent.com отдает ресурсы с заголовком `Content-Type: text/plain`. [RawGit](http://rawgit.com/) решает эту проблему.
